### PR TITLE
Update package.json - remove globalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,11 +54,6 @@
     "sinon-chai": "^3.7.0",
     "typescript": "~5.4.5"
   },
-  "globalDependencies": [
-    {
-      "admin": ">=6.13.16"
-    }
-  ],
   "main": "main.js",
   "files": [
     "admin{,/!(src)/**}/!(tsconfig|tsconfig.*|.eslintrc).{json,json5}",


### PR DESCRIPTION
globalDependencies is a section to be located at io-package.json (where it exists in meantime)

Adding to package.json was cause be an incorrect note at review.