### PR TITLE
Adding additional AES-GCM encryption as v2

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1,6 +1,6 @@
 const dgram = require('dgram');
 const EventEmitter = require('events');
-const { encrypt, decrypt, defaultKey } = require('./encryptor');
+const { encrypt, decrypt, defaultKey, defaultKeyGCM, encryptGCM, decryptGCM } = require('./encryptor');
 
 const commandsMap = {
     'bind': 'bindok',
@@ -17,12 +17,14 @@ class Connection extends EventEmitter {
         super();
         this.logger = logger;
         this.socket = dgram.createSocket('udp4');
+        this.socketScan = dgram.createSocket('udp4');
         this.devices = {};
+        this.deviceEncVer = {};
 
-        this.socket.on('message', this.handleResponse.bind(this));
+        this.socketScan.on('message', this.handleResponse.bind(this));
 
-        this.socket.on('listening', () => {
-            const socketAddress = this.socket.address();
+        this.socketScan.on('listening', () => {
+            const socketAddress = this.socketScan.address();
             this.logger.info(`Socket server is listening on ${socketAddress.address}:${socketAddress.port}`);
 
             this.scan(address);
@@ -31,90 +33,142 @@ class Connection extends EventEmitter {
         this.socket.on('error', (error) => {
             this.logger.error(error.message);
         });
+        this.socketScan.on('error', (error) => {
+            this.logger.error(error.message);
+        });
 
         this.socket.bind();
+        this.socketScan.bind();
     }
 
     registerKey(deviceId, key) {
+        this.logger.debug(`Registering key: ${deviceId} - ${key}`);
         this.devices[deviceId] = key;
     }
 
     getEncryptionKey(deviceId) {
         return this.devices[deviceId] || defaultKey;
     }
+    
+    registerEncVersion(deviceId, encVer) {
+        this.logger.debug(`Registering encVer: ${deviceId} - ${encVer}`);
+        this.deviceEncVer[deviceId] = encVer;
+    }
 
+    getEncVersion(deviceId) {
+        return this.deviceEncVer[deviceId] || 1;
+    }
+    
     scan(ipAddresses) {
-        const message = Buffer.from(JSON.stringify({ t: 'scan' }));
+        const message = Buffer.from(JSON.stringify({ cid: "app", t: 'scan', i: 1, uid: 0 }));
 
         ipAddresses.split(';').forEach((deviceAddress) => {
-            this.logger.debug(`Test address ${deviceAddress} for available device`);
-            this.socket.send(message, 0, message.length, 7000, deviceAddress);
+            this.logger.debug(`Test address ${deviceAddress} for available device with message: ${message}`);
+            this.socketScan.send(message, 0, message.length, 7000, deviceAddress);
         });
     }
 
-    async sendRequest(address, port, key, payload) {
+    async sendRequest(address, port, payload, encVersion) {
         return new Promise((resolve, reject) => {
             let requestTimeout;// eslint-disable-line prefer-const
-            const request = {
-                cid: 'app',
-                i: key === defaultKey ? 1 : 0,
-                t: 'pack',
-                uid: 0,
-                tcid: payload.mac,
-                pack: encrypt(payload, key)
-            };
-
-            this.logger.debug(`Request: ${JSON.stringify(request)}`);
-
-            const messageHandler = (msg, rinfo) => {
-                const message = JSON.parse(msg.toString());
-                let response;
-
-                // Check device address data
-                if (rinfo.address !== address || rinfo.port !== port) {
-                    this.logger.error(`Received message from unexpected address ${rinfo.address}:${rinfo.port}`);
-                    return;
+            try {
+                let pack;
+                let tag;
+                const key = this.getEncryptionKey(address);
+                if (encVersion == undefined) {
+                    encVersion = this.getEncVersion(address);
                 }
-
-                this.logger.debug(`Received message from ${message.cid} (${rinfo.address}:${rinfo.port}) ${msg.toString()}`);
-
-                try {
-                    response = decrypt(message.pack, key);
-                    this.logger.debug(`Decrypted message: ${JSON.stringify(response)}`);
-                } catch {
-                    this.logger.error(`Can not decrypt message from ${message.cid} (${rinfo.address}:${rinfo.port}) with key ${key}`);
-                    this.logger.debug(message.pack);
-                    return;
+                if (encVersion == 1) {
+                    pack = encrypt(payload, key);
+                } else {
+                    let {encPack, encTag} = encryptGCM(payload, key);
+                    pack = encPack;
+                    tag = encTag;
                 }
+                
+                this.logger.debug(`Payload: ${JSON.stringify(payload)}`);
+                this.logger.silly(`key: ${key}`);
+                this.logger.silly(`pack: ${pack}`);
+                this.logger.silly(`tag: ${tag}`);
+                this.logger.silly(`encVersion: ${encVersion}`);
+                const request = {
+                    cid: 'app',
+                    i: payload.t === 'bind' ? 1 : key === defaultKey ? 1 : 0,
+                    t: 'pack',
+                    uid: 0,
+                    tcid: payload.mac,
+                    pack: pack,
+                    tag: tag,
+                };
 
-                if (response.t !== commandsMap[payload.t]) {
-                    this.logger.error(`Response command type ${response.t} does not match expected ${commandsMap[payload.t]}`);
-                    return;
-                }
+                const messageHandler = (msg, rinfo) => {
+                    const message = JSON.parse(msg.toString());
+                    this.logger.debug(`Received message from ${message.cid} (${rinfo.address}:${rinfo.port}) ${msg.toString()} - ${JSON.stringify(rinfo)}`);
+                    let response;
 
-                if (response.mac !== payload.mac) {
-                    this.logger.error(`Response mac ${response.mac} does not match expected ${payload.mac}`);
-                    return;
-                }
+                    // Check device address data
+                    if (rinfo.address !== address || rinfo.port !== port) {
+                        return;
+                    }
 
-                if (this.socket && this.socket.off) {
-                    this.socket.off('message', messageHandler);
-                }
+                    const decKey = this.getEncryptionKey(rinfo.address);
+                    //const decTag = payload.t === 'bind' ? undefined : message.tag;
+                    const decTag = message.tag;
+                    let encVersion = decTag != undefined ? 2 : 1;
+                    if (encVersion == 2) {
+                        this.registerEncVersion(rinfo.address, encVersion);
+                    } else {
+                       encVersion = this.getEncVersion(rinfo.address); 
+                    }
+                    this.logger.silly(`decKey: ${decKey}`);
+                    this.logger.silly(`decTag: ${decTag}`);
+                    this.logger.silly(`encVersion: ${encVersion}`);
+                    
+                    try {
+                        if (encVersion == 1) {
+                            response = decrypt(message.pack, decKey, decTag);
+                            this.logger.debug(`sendRequest - Response data: ${JSON.stringify(response)}`);
+                        } else if (encVersion == 2) {
+                            response = decryptGCM(message.pack, decKey, decTag);
+                            this.logger.debug(`sendRequest - Response data: ${JSON.stringify(response)}`);
+                        }
+                    } catch (e) {
+                        this.logger.error(`Can not decrypt message from ${message.cid} (${rinfo.address}:${rinfo.port}) with key ${decKey} and tag ${decTag}`);
+                        this.logger.error(e.stack);
+                        return;
+                    }
 
-                clearTimeout(requestTimeout);
-                resolve(response);
-            };
+                    if (response.t !== commandsMap[payload.t]) {
+                        this.logger.debug(`No matching command: ${response.t}`);
+                        return;
+                    }
 
-            this.logger.debug(`Sending request to ${address}:${port}: ${JSON.stringify(payload)}`);
+                    if (response.mac !== payload.mac) {
+                        this.logger.debug(`No matching mac ${response.mac} - ${payload.mac}`);
+                        return;
+                    }
 
-            this.socket.on('message', messageHandler);
+                    if (this.socket && this.socket.off) {
+                        this.socket.off('message', messageHandler);
+                    }
 
-            const toSend = Buffer.from(JSON.stringify(request));
-            this.socket.send(toSend, 0, toSend.length, port, address);
-            requestTimeout = setTimeout(() => {
-                clearTimeout(requestTimeout);
-                reject(new Error(`Request to ${address}:${port} timed out`));
-            }, this.requestTimeoutMs);
+                    clearTimeout(requestTimeout);
+                    resolve(response);
+                };
+
+                this.logger.debug(`Sending request to ${address}:${port}: ${JSON.stringify(request)}`);
+
+                this.socket.on('message', messageHandler);
+
+                const toSend = Buffer.from(JSON.stringify(request));
+                this.socket.send(toSend, 0, toSend.length, port, address);
+                requestTimeout = setTimeout(() => {
+                    clearTimeout(requestTimeout);
+                    reject(new Error(`Request to ${address}:${port} timed out`));
+                }, this.requestTimeoutMs);
+            } catch (e) {
+                this.logger.error(e.stack);
+            }
         });
     }
 
@@ -129,17 +183,29 @@ class Connection extends EventEmitter {
             return;
         }
 
-        const key = this.getEncryptionKey(rinfo.address);
+        const tag = message.tag;
+        const encVersion = tag != undefined ? 2 : 1;
+        const key = encVersion == 1 ? defaultKey : defaultKeyGCM;
+
+        this.logger.silly(`key: ${key}`);
+        this.logger.silly(`tag: ${tag}`);
+        this.logger.silly(`encVersion: ${encVersion}`);
 
         try {
-            response = decrypt(message.pack, key);
-        } catch {
-            this.logger.error(`Can not decrypt message from ${message.cid} (${rinfo.address}:${rinfo.port}) with key ${key}`);
-            this.logger.debug(message.pack);
+            if (encVersion == 1) {
+                response = decrypt(message.pack, key, tag);
+                this.logger.debug(`handleResponse - Response data: ${JSON.stringify(response)}`);
+            } else if (encVersion == 2) {
+                response = decryptGCM(message.pack, key, tag);
+                this.logger.debug(`handleResponse - Response data: ${JSON.stringify(response)}`);
+            }
+        } catch (e) {
+            this.logger.error(`handleResponse - Can not decrypt message from ${message.cid} (${rinfo.address}:${rinfo.port}) with key ${key} and tag ${tag}`);
+            this.logger.error(e.stack);
             return;
         }
 
-        this.emit(response.t, response, rinfo);
+        this.emit(response.t, response, rinfo, encVersion);
     }
 }
 

--- a/lib/device_manager.js
+++ b/lib/device_manager.js
@@ -1,6 +1,6 @@
 const EventEmitter = require('events');
 const Connection = require('./connection');
-const { defaultKey } = require('./encryptor');
+const { defaultKey, defaultKeyGCM } = require('./encryptor');
 const TEMPERATURE_SENSOR_OFFSET = -40;
 
 // https://github.com/tomikaa87/gree-remote
@@ -42,37 +42,68 @@ class DeviceManager extends EventEmitter {
         }, DeviceScanTimeoutMs);
     }
 
-    async _registerDevice(message, rinfo) {
+    async sendRegisterDevice(message, rinfo, encVersion) {
         const deviceId = message.cid || message.mac;
-        this.logger.info(`New device found: ${message.name} (mac: ${deviceId}), binding...`);
+        this.logger.info(`New device found: ${message.name} (mac: ${deviceId}), binding encVer ${encVersion}...`);
         const { address, port } = rinfo;
 
         try {
-            const { key } = await this.connection.sendRequest(address, port, defaultKey, {
+            const { key } = await this.connection.sendRequest(address, port, {
+                cid: "app",
+                tcid: deviceId,
                 mac: deviceId,
                 t: 'bind',
                 uid: 0
-            });
-            const device = {
-                ...message,
-                address,
-                port,
-                key,
-                t: undefined
-            };
+            }, encVersion);
+            
+            if (key) {
+                const device = {
+                    ...message,
+                    address,
+                    port,
+                    key,
+                    encVersion,
+                    t: undefined
+                };
 
-            this.devices[deviceId] = device;
+                this.devices[deviceId] = device;
 
-            this.connection.registerKey(rinfo.address, key);
+                this.connection.registerKey(rinfo.address, key);
+                this.connection.registerEncVersion(address, encVersion);
 
-            this.emit('device_bound', deviceId, device);
-            this.logger.info(`New device bound: ${device.name} (${device.address}:${device.port})`);
+                this.emit('device_bound', deviceId, device);
+                this.logger.info(`New device bound: ${device.name} (${device.address}:${device.port}) with encryption v${encVersion}`);
 
-            return device;
-        } catch(error) {
-            this.logger.error(`Failed to bind device ${deviceId}: ${error.message}`);
+                return device;
+            }
+            return null;
+        } catch (e) {
             return null;
         }
+    }
+
+    async _registerDevice(message, rinfo) {
+        const { address, port } = rinfo;
+        let encVersion = this.connection.getEncVersion(address);
+        let device;
+        try {
+            device = await this.sendRegisterDevice(message, rinfo, encVersion);
+            if (!device) {
+                this.logger.info(`Registering failed, trying next encVer...`);
+                this.connection.registerEncVersion(address, (encVersion) % 2 + 1); //increase encryption version
+                encVersion = this.connection.getEncVersion(address);
+                //set proper default keys for binding
+                if (encVersion == 1) {
+                    this.connection.registerKey(address, defaultKey);
+                } else if (encVersion == 2) {
+                    this.connection.registerKey(address, defaultKeyGCM);
+                }
+                device = await this.sendRegisterDevice(message, rinfo, encVersion);
+            }
+        } catch (e) {
+            this.logger.error(e.stack);
+        }
+        return device;
     }
 
     getDevices() {
@@ -92,7 +123,7 @@ class DeviceManager extends EventEmitter {
             t: 'status'
         };
 
-        const response = await this.connection.sendRequest(device.address, device.port, device.key, payload);
+        const response = await this.connection.sendRequest(device.address, device.port, payload);
         const deviceStatus = response.cols.reduce((acc, key, index) => ({
             ...acc,
             [key]: response.dat[index]
@@ -120,7 +151,7 @@ class DeviceManager extends EventEmitter {
             t: 'cmd'
         };
 
-        const response = await this.connection.sendRequest(device.address, device.port, device.key, payload);
+        const response = await this.connection.sendRequest(device.address, device.port, payload);
         const deviceStatus = response.opt.reduce((acc, key, index) => ({
             ...acc,
             [key]: response.p[index]

--- a/lib/encryptor.js
+++ b/lib/encryptor.js
@@ -1,16 +1,46 @@
 const crypto = require('crypto');
 
 const defaultKey = 'a3K8Bx%2r8Y7#xDh';
+const defaultKeyGCM = Buffer.from('7B7978414841595F4C6D367062432F3C', "hex") //'{yxAHAY_Lm6pbC/<';
+
+const ECB_ALG = 'aes-128-ecb';
+
+const GCM_ALG = 'aes-128-gcm';
+const GCM_NONCE = Buffer.from('5440784449675a516c5e6313',"hex"); //'\x54\x40\x78\x44\x49\x67\x5a\x51\x6c\x5e\x63\x13';
+const GCM_AEAD = Buffer.from('qualcomm-test');
+
+function encryptGCM(data, key = defaultKeyGCM) {
+    const cipher = crypto.createCipheriv(GCM_ALG, key, GCM_NONCE);
+    cipher.setAAD(GCM_AEAD);
+    const str = cipher.update(JSON.stringify(data), 'utf8', 'base64');
+    const encPack = str + cipher.final('base64');
+    const rawTag = cipher.getAuthTag();
+    const encTag = rawTag.toString('base64').toString("utf-8");
+    return {encPack, encTag};
+}
+
+function decryptGCM(data, key = defaultKeyGCM, tag) {
+    const decipher = crypto.createDecipheriv(GCM_ALG, key, GCM_NONCE);
+    decipher.setAAD(GCM_AEAD);
+    if (tag) {
+        const decTag = Buffer.from(tag, 'base64');
+        decipher.setAuthTag(decTag);
+    }
+    const str = decipher.update(data, 'base64', 'utf8');
+    const response = JSON.parse(str + decipher.final('utf8'));
+
+    return response;
+}
 
 function encrypt(data, key = defaultKey) {
-    const cipher = crypto.createCipheriv('aes-128-ecb', key, '');
+    const cipher = crypto.createCipheriv(ECB_ALG, key, '');
     const str = cipher.update(JSON.stringify(data), 'utf8', 'base64');
-    const request = str + cipher.final('base64');
-    return request;
+    const pack = str + cipher.final('base64');
+    return pack;
 }
 
 function decrypt(data, key = defaultKey) {
-    const decipher = crypto.createDecipheriv('aes-128-ecb', key, '');
+    const decipher = crypto.createDecipheriv(ECB_ALG, key, '');
     const str = decipher.update(data, 'base64', 'utf8');
     const response = JSON.parse(str + decipher.final('utf8'));
 
@@ -19,6 +49,9 @@ function decrypt(data, key = defaultKey) {
 
 module.exports = {
     defaultKey,
+    defaultKeyGCM,
     encrypt,
-    decrypt
+    decrypt,
+    encryptGCM,
+    decryptGCM
 };


### PR DESCRIPTION
This adds the AES-GCM encryption method which is needed for some devices on newer firmware versions (e.g. gree model 32776, v1.23). The discovery happens automatically during the bind process with a retry on v2 if v1 fails. Key and encryption handling was put into connection.js with little override possibilities to ensure automatic handling is working. Additional logging was added.
A bind-scan socked was added to split normal communication from binding.

This should fix #28.